### PR TITLE
Issue #19 Payable APIs - NYT (2/3)

### DIFF
--- a/erikvold/Payable APIs/NYT/.gitignore
+++ b/erikvold/Payable APIs/NYT/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pid
+settings.json

--- a/erikvold/Payable APIs/NYT/manifest.yaml
+++ b/erikvold/Payable APIs/NYT/manifest.yaml
@@ -1,0 +1,32 @@
+basePath: /
+host: 10.244.108.173:6006
+info:
+  contact: {email: erikvvold@gmail.com, name: Erik Vold}
+  description: Get NYT movie reviews by keyword.
+  title: NYT Movie Reviews
+  x-21-category: utilities
+  x-21-github-project-url: https://github.com/erikvold/nyt-movie-reviews21
+  x-21-keywords: [reviews, nyt, new york, new york times, erikvold, movies, critics]
+  x-21-quick-buy: "$ 21 buy url http://10.244.233.43:6006/?keyword=Batman\n\n\
+    # Output:\n\
+    # {\n\
+    #   \"results\": [...]\n\
+    # }"
+  x-21-total-price: {max: 2500, min: 2500}
+paths:
+  /:
+    get:
+      consumes: [application/x-www-form-urlencoded]
+      produces: [application/json]
+      responses:
+        200:
+          description: NYT movie reviews by keyword.
+          schema:
+            type: object
+            properties:
+              results:
+                type: array
+      summary: Get NYT movie reviews by keyword.
+schemes: [http]
+swagger: '2.0'
+x-21-manifest-path: /manifest

--- a/erikvold/Payable APIs/NYT/nyt-movie-reviews21-server.py
+++ b/erikvold/Payable APIs/NYT/nyt-movie-reviews21-server.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+import psutil
+import subprocess
+import os
+import sys
+import yaml
+
+from flask import Flask
+from flask import request
+
+from two1.lib.wallet.two1_wallet import Wallet
+from two1.lib.bitserv.flask import Payment
+
+from nyt_movie_reviews21 import reviews21
+
+app = Flask(__name__)
+
+# setup wallet
+wallet = Wallet()
+payment = Payment(app, wallet)
+
+
+# hide logging
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
+
+@app.route('/manifest')
+def manifest():
+    """Provide the app manifest to the 21 crawler.
+    """
+    with open('./manifest.yaml', 'r') as f:
+        manifest = yaml.load(f)
+    return json.dumps(manifest)
+
+
+@app.route('/')
+@payment.required(2500)
+def reviews():
+    try:
+        query = request.args['keyword']
+    except KeyError:
+        return 'HTTP Status 400: URI keyword parameter is missing from your request.', 400
+
+    try:
+        data = reviews21(query)
+        response = json.dumps(data, indent=2, sort_keys=True)
+        return response
+    except ValueError as e:
+        return 'HTTP Status 400: {}'.format(e.args[0]), 400
+
+
+if __name__ == '__main__':
+    if 'daemon' not in sys.argv:
+        pid_file = './nyt-movie-reviews21.pid'
+        if os.path.isfile(pid_file):
+            pid = int(open(pid_file).read())
+            os.remove(pid_file)
+            try:
+                p = psutil.Process(pid)
+                p.terminate()
+            except:
+                pass
+        try:
+            p = subprocess.Popen(['python3', 'nyt-movie-reviews21-server.py', 'daemon'])
+            open(pid_file, 'w').write(str(p.pid))
+        except subprocess.CalledProcessError:
+            raise ValueError("error starting nyt-movie-reviews21-server.py daemon")
+    else:
+        print ("Server running...")
+        app.run(host='0.0.0.0', port=6006)

--- a/erikvold/Payable APIs/NYT/nyt_movie_reviews21.py
+++ b/erikvold/Payable APIs/NYT/nyt_movie_reviews21.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import platform
+import requests
+import shutil
+import sys
+import urllib.parse
+
+__all__ = ["reviews21"]
+
+settings_data = open('settings.json')
+apiKey = json.load(settings_data)['key']
+
+def get_json(uri):
+    raw = requests.get(uri)
+    data = raw.json()
+    return data
+
+
+def reviews21(query):
+    json = get_json("".join([
+      'http://api.nytimes.com/svc/movies/v2/reviews/search.json?api-key=',
+      apiKey,
+      '&query=',
+      urllib.parse.quote(query)
+    ]))
+
+    info = {
+        'results': json['results'],
+    }
+
+    return info
+
+if __name__ == '__main__':
+    url = sys.argv[1]
+    data = reviews21(url)
+    formatted_data = json.dumps(data, indent=2, sort_keys=True)
+    print(formatted_data)

--- a/erikvold/Payable APIs/NYT/requirements.txt
+++ b/erikvold/Payable APIs/NYT/requirements.txt
@@ -1,0 +1,4 @@
+Flask==0.10.1
+PyYAML==3.11
+requests==2.7.0
+psutil

--- a/erikvold/Payable APIs/NYT/settings_default.json
+++ b/erikvold/Payable APIs/NYT/settings_default.json
@@ -1,0 +1,4 @@
+{
+ "key": "<API_KEY_HERE>"
+}
+


### PR DESCRIPTION
Resolves #19 
Bitcoin address: 19wwwqmWmDS4MwZyW66fqigHsDEvFTaQyc
Description: Creates a payable API route that will return a NYT movie review by keyword.